### PR TITLE
Implement subtle background color change on color click in light mode

### DIFF
--- a/index.css
+++ b/index.css
@@ -361,7 +361,7 @@ Media queries
 
     .color-result {
         width: 100%;
-        height: 60vh;
+        height: 65vh;
         transition: 0.5s;
     }
 
@@ -383,14 +383,14 @@ Media queries
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        margin: 1.5em 0 0 0;
+        margin: 1em 0;
     }
 
     footer nav {
         display: flex;
         justify-content: center;
         align-items: center;
-        gap: 1.5em;
+        gap: 1.75em;
     }
     
     .footer-text {
@@ -400,7 +400,7 @@ Media queries
     }
 
     .footer-icon {
-        font-size: 1.25em;
+        font-size: 0.75em;
         margin-bottom: 0;
     }
 

--- a/index.js
+++ b/index.js
@@ -27,13 +27,13 @@ fetch(defaultUrl)
         let htmlString = ''
         for(let color of colors){
             htmlString += `
-            <section class='color-result-container'>
-                <div class='color-result' style='background-color:${color.hex.value};'>
-                </div>
-                <div class='color-result-hex-code'>
-                    ${color.hex.value}
-                </div>
-            </section> 
+                <section class='color-result-container'>
+                    <div class='color-result' style='background-color:${color.hex.value};'>
+                    </div>
+                    <div class='color-result-hex-code'>
+                        ${color.hex.value}
+                    </div>
+                </section> 
             `
         } 
         colorContainerHtml.innerHTML = htmlString 
@@ -55,13 +55,13 @@ getColorSchemeBtn.addEventListener('click', function(){
             let htmlString = ''
             for (let color of colors){
                 htmlString += `
-                <section class='color-result-container'>
-                    <div class='color-result' style='background-color:${color.hex.value};'>
-                    </div>
-                    <div class='color-result-hex-code'>
-                        ${color.hex.value}
-                    </div>
-                </section>
+                    <section class='color-result-container'>
+                        <div class='color-result' style='background-color:${color.hex.value};'>
+                        </div>
+                        <div class='color-result-hex-code'>
+                            ${color.hex.value}
+                        </div>
+                    </section>
                 `
             }
             colorContainerHtml.innerHTML = htmlString
@@ -73,19 +73,29 @@ toggleThemeBtn.addEventListener('click', function(){
     document.body.classList.toggle('dark-theme');
 })
 
-
 // Copy color to clipboard when clicked
-document.body.addEventListener('click', function(e) {
-    if (e.target.classList.contains('color-result')) {
-        const hexCode = e.target.nextElementSibling.textContent;
+document.body.addEventListener('click', async function(e) {
+    if (e.target.classList.contains('color-result') && !document.body.classList.contains('dark-theme')) {
+        const hexCode = e.target.nextElementSibling.textContent.trim();
 
-        let textarea = document.createElement('textarea');
-        textarea.value = hexCode;
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textarea);
+        // Extracting the RGB values from the HEX code
+        const r = parseInt(hexCode.slice(1, 3), 16);
+        const g = parseInt(hexCode.slice(3, 5), 16);
+        const b = parseInt(hexCode.slice(5, 7), 16);
+        
+        // Setting the background color of the body to the RGBA value
+        document.body.style.backgroundColor = `rgba(${r}, ${g}, ${b}, 0.3)`;
 
-        console.log('Color copied to clipboard');
+        try {
+            await navigator.clipboard.writeText(hexCode);
+            console.log('Color copied to clipboard');
+        } catch (err) {
+            console.error('Failed to copy text: ', err);
+        }
+    } else {
+        // Reset the background color when clicking elsewhere
+        document.body.style.backgroundColor = '';
     }
 });
+
+


### PR DESCRIPTION
This commit implements the following features:

1. When a color is clicked from the displayed color schemes, the entire page's background color changes to that selected color with a reduced opacity of 0.3. This subtle change gives a preview of the color to the user.

2. The above feature is only activated in light mode. When the theme is switched to dark mode, clicking on colors won't affect the background to maintain the dark theme's integrity and user experience.

Note: The addition of the `!document.body.classList.contains('dark-theme')` condition ensures that the background color changing logic is only executed in light mode.
