### PR TITLE
Add Push Effect to Color Tiles

### DIFF
--- a/index.css
+++ b/index.css
@@ -95,6 +95,16 @@ Header
     box-shadow: 0 0 3px #3D4B60;
 }
 
+.color-input:hover,
+.color-btn:hover {
+    transform: scale(1.05);
+    transition: transform 0.3s ease-in-out;
+}
+
+.color-input:active,
+.color-btn:active {
+    transform: scale(0.95) !important;
+}
 
 .color-input:hover,
 .color-scheme-dropdown:hover,
@@ -127,6 +137,7 @@ Main section
     display: flex;
     align-items: center;
     justify-content: center;
+    transition: transform 0.3s ease-in-out;
 }
 
 .copy-text {
@@ -139,6 +150,10 @@ Main section
     transform: scale(1.025);
     border-radius: 10px;
     cursor: pointer;
+}
+
+.color-result:active {
+    transform: scale(0.95) !important;
 }
 
 .color-result-hex-code {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
                         <option value='triad'>Triad</option>
                     </select>
                 </div>
-                <button id='color-btn' class='color-btn header-item'>Get Color Scheme</button>
+                <button id='color-btn' class='color-btn header-item' role='button'>Get Color Scheme</button>
             </div>
         </header>
         


### PR DESCRIPTION
- Modified the `:hover` and `:active` pseudo-classes for the `.color-result`, `.color-input` and `.color-btn` class.
- Tweaked the CSS transform property to create the desired push effect.